### PR TITLE
Nuget Centralized Package Management

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
           # The remote certificate is invalid because of errors in the certificate chain: UntrustedRoot
           apt install --yes --no-install-recommends ca-certificates
 
-          apt install --yes --no-install-recommends dotnet6
+          apt install --yes --no-install-recommends dotnet7
 
       - name: Compile the main solution
         run: dotnet build

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,16 @@
+<!-- Workaround for Central Package Management taken from
+     https://github.com/NuGet/Home/issues/11949 and
+     https://github.com/microsoft/MSBuildSdks/blob/22cee25ad037827b54b75b6ee1c59a5bc75a744f/src/CentralPackageVersions/Sdk/Sdk.targets#L70-L76
+
+     TODO: when upgrading to .NET8.0, we can simply use <PackageReference Include="FSharp.Core" VersionOverride="7.0.0" /> for example, and it
+     just works (example of a project that works today this way: fantomas)
+-->
+<Project>
+    <ItemGroup Condition=" '$(EnableCentralPackageVersions)' != 'false' ">
+        <PackageReference
+            Update="FSharp.Core"
+            Condition="'$(MSBuildProjectExtension)' == '.fsproj' And '$(DisableImplicitFSharpCoreReference)' != 'true' And '$(UpdateImplicitFSharpCoreReference)' != 'false'"
+            IsImplicitlyDefined="true"
+        />
+    </ItemGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,17 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="StackExchange.Redis" Version="2.0.513" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="NUnit" Version="3.9.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.App" Version="2.1.34" />
+    <PackageVersion Include="Giraffe" Version="3.1.0" />
+    <PackageVersion Include="Giraffe.Razor" Version="1.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebSockets" Version="2.1.1" />
+    <PackageVersion Include="TaskBuilder.fs" Version="2.1.0" />
+  </ItemGroup>
+</Project>

--- a/src/FX.Console/FX.Console.fsproj
+++ b/src/FX.Console/FX.Console.fsproj
@@ -11,6 +11,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\FX.Core\FX.Core.fsproj" />
-    <PackageReference Include="FSharp.Core" Version="6.0.1" />
+    <PackageReference Include="FSharp.Core" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/src/FX.Console/FX.Console.fsproj
+++ b/src/FX.Console/FX.Console.fsproj
@@ -11,6 +11,5 @@
 
   <ItemGroup>
     <ProjectReference Include="..\FX.Core\FX.Core.fsproj" />
-    <PackageReference Include="FSharp.Core" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/src/FX.Core/FX.Core.fsproj
+++ b/src/FX.Core/FX.Core.fsproj
@@ -12,7 +12,7 @@
     <Compile Include="Exchange.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="6.0.1" />
+    <PackageReference Include="FSharp.Core" Version="7.0.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.0.513" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/src/FX.Core/FX.Core.fsproj
+++ b/src/FX.Core/FX.Core.fsproj
@@ -12,8 +12,7 @@
     <Compile Include="Exchange.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="7.0.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.0.513" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="StackExchange.Redis" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 </Project>

--- a/src/FX.Tests/FX.Tests.csproj
+++ b/src/FX.Tests/FX.Tests.csproj
@@ -5,12 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="FSharp.Core" Version="7.0.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.0.513" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="StackExchange.Redis" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Class1.cs" />

--- a/src/FX.Tests/FX.Tests.csproj
+++ b/src/FX.Tests/FX.Tests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="FSharp.Core" Version="6.0.1" />
+    <PackageReference Include="FSharp.Core" Version="7.0.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.0.513" />

--- a/src/WebSocketApp/WebSocketApp.fsproj
+++ b/src/WebSocketApp/WebSocketApp.fsproj
@@ -23,12 +23,12 @@
     <Compile Include="Middleware\WebSocketMiddleware.fs" />
     <Compile Include="Program.fs" />
     <None Include="web.config" CopyToOutputDirectory="PreserveNewest" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.34" />
-    <PackageReference Include="Giraffe" Version="3.1.0" />
-    <PackageReference Include="Giraffe.Razor" Version="1.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Giraffe" />
+    <PackageReference Include="Giraffe.Razor" />
     <Watch Include="**\*.cshtml" Exclude="bin\**\*" />
-    <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.1.1" />
-    <PackageReference Include="TaskBuilder.fs" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.WebSockets" />
+    <PackageReference Include="TaskBuilder.fs" />
     <ProjectReference Include="..\FX.Core\FX.Core.fsproj" />
   </ItemGroup>
 </Project>

--- a/src/WebSocketApp/WebSocketApp.fsproj
+++ b/src/WebSocketApp/WebSocketApp.fsproj
@@ -23,9 +23,9 @@
     <Compile Include="Middleware\WebSocketMiddleware.fs" />
     <Compile Include="Program.fs" />
     <None Include="web.config" CopyToOutputDirectory="PreserveNewest" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.34" />
     <PackageReference Include="Giraffe" Version="3.1.0" />
-    <PackageReference Include="Giraffe.Razor" Version="1.3.*" />
+    <PackageReference Include="Giraffe.Razor" Version="1.3.0" />
     <Watch Include="**\*.cshtml" Exclude="bin\**\*" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.1.1" />
     <PackageReference Include="TaskBuilder.fs" Version="2.1.0" />


### PR DESCRIPTION
In order to have version numbers for all projects in a single file (and this way avoiding the problem of depending on more than one version for the same package).